### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+Contributing
+============
+
+Want to contribute, but not sure where to start? Check out our [issue board](http://waffle.io/storj/core)! 
+
+Contributor License Agreement
+-----------------------------
+
+By submitting pull requests, you agree that your work may be licensed under GNU Affero General Public License Version 3 (or later).
+You also assert that you have completed the [Contributor License Agreement](https://storj.io/cla).
+
+Pull Requests for Swag
+----------------------
+We love pull requests, so to encourage more of them we are offering
+awesome swag. Only SIGNIFICANT pull requests count. Fixing a comma
+doesn’t count, but fixing a bug, adding more test coverage, or writing
+guides & documentation does.
+
+- Make 1x pull requests to get into the contributors list and website
+- Make 2x pull requests, we will send you a packet of stickers
+- Make 5x pull requests, and we will send you a t-shirt and more stickers
+- Make 10x pull requests, and you get a job interview with James + other swag
+
+If we miss a milestones (probably because we are working hard), just let
+us know so we can get you your swag. 
+
+Style Guide
+-----------
+We adhere to
+[Felix's Node.js Style Guide](https://github.com/felixge/node-style-guide).
+Please take the time to review the style guide and take care to follow it.


### PR DESCRIPTION
Tome pointed out that there is no CONTRIBUTING.md file, which `https://storj.io/developers` links to. Proposed Contributing.md file to fix that so that it links properly to our contribution guidelines.