### PR TITLE
Add a total row to output when more than 1 share

### DIFF
--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -8,6 +8,7 @@ const utils = require('../lib/utils');
 const Table = require('cli-table');
 const colors = require('colors/safe');
 const storjshare_status = require('commander');
+const bytes = require('bytes');
 
 storjshare_status
   .description('prints the status of all managed shares')
@@ -21,25 +22,44 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
         head: ['cyan', 'bold'],
         border: []
       },
-      colWidths: [45, 10, 10, 10, 10, 10]
+      colWidths: [42, 9, 10, 10, 7, 10]
     });
+    var totalShares = shares.length;
+    var totalUptimeMs=0;
+    var totalStopped=0;
+    var totalRunning=0;
+    var totalErrored=0;
+    var totalUnknown=0;
+    var totalRestarts=0;
+    var totalPeers=0;
+    var totalSpaceUsed=0;
+    var totalPercentUsed=0;
     shares.forEach((share) => {
       let status = '?';
 
       switch (share.state) {
         case 0:
           status = colors.gray('stopped');
+          totalStopped++;
           break;
         case 1:
           status = colors.green('running');
+          totalRunning++;
           break;
         case 2:
           status = colors.red('errored');
+          totalErrored++;
           break;
         default:
           status = 'unknown';
+          totalUnknown++;
       }
 
+      totalUptimeMs += share.meta.uptimeMs;
+      totalRestarts += share.meta.numRestarts || 0;
+      totalPeers += share.meta.farmerState.totalPeers || 0;
+      totalSpaceUsed += bytes(share.meta.farmerState.spaceUsed);
+      totalPercentUsed += parseInt(share.meta.farmerState.percentUsed);
       table.push([
         `${share.id}\n  → ${share.config.storagePath}`,
         status,
@@ -50,6 +70,22 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
           `(${share.meta.farmerState.percentUsed}%)`
       ]);
     });
+
+    if (totalShares > 1) {
+      table.push([
+        '     ' + 
+        'Running: ' + (totalRunning + '    ').slice(0,5) + ' ' +
+        `Stopped: ${totalStopped}\n     ` + 
+        'Errored: ' + (totalErrored + '    ').slice(0,5) + ' ' +
+        `Unknown: ${totalUnknown}`,
+        'Average\nTotal',
+        prettyMs(totalUptimeMs / totalShares) + '\n' + prettyMs(totalUptimeMs),
+        (totalRestarts / totalShares).toFixed(0) + '\n' + totalRestarts ,
+        (totalPeers / totalShares).toFixed(0) + '\n' + totalPeers,
+        bytes(totalSpaceUsed / totalShares) + '\n' + bytes(totalSpaceUsed) +
+        '\n(' + (totalPercentUsed / totalShares).toFixed(0) + '%)'
+      ]);
+    }
     console.log('\n' + table.toString());
     sock.end();
   });


### PR DESCRIPTION
Resize columns for better fit.
Show totals of running, stopped, errored, and unknown statuses.
Show total uptime and average uptime per share.
Show total restarts and average restarts per share.
Show total peers and average peers per share.
Show total space used and average space used per share.
Show a percentage of total space used.
Add 'bytes' for processing of space used.