### PR TITLE
Add used space in raw bytes as well

### DIFF
--- a/script/farmer.js
+++ b/script/farmer.js
@@ -48,6 +48,7 @@ function updatePercentUsed() {
   config.storageManager._storage.size((err, result) => {
     if (result) {
       farmerState.spaceUsed = bytes(result);
+      farmerState.spaceUsedBytes = result;
       farmerState.percentUsed = ((result / spaceAllocation) * 100).toFixed();
     }
   });


### PR DESCRIPTION
Make the raw bytes of used space available via rpc in addition to a formatted string.