### PR TITLE
Remove symbols

### DIFF
--- a/bin/storjshare.js
+++ b/bin/storjshare.js
@@ -7,7 +7,7 @@ const {version} = require('../package');
 const {software: core, protocol} = require('storj-lib').version;
 
 storjshare
-  .version(`daemon: ${version}, core: ${core}, protocol: ${protocol}`)
+  .version(`\n  * daemon: ${version}, core: ${core}, protocol: ${protocol}`)
   .command('start', 'start a farming node')
   .command('stop', 'stop a farming node')
   .command('restart', 'restart a farming node')

--- a/bin/storjshare.js
+++ b/bin/storjshare.js
@@ -7,7 +7,7 @@ const {version} = require('../package');
 const {software: core, protocol} = require('storj-lib').version;
 
 storjshare
-  .version(`\n  * daemon: ${version}, core: ${core}, protocol: ${protocol}`)
+  .version(`daemon: ${version}, core: ${core}, protocol: ${protocol}`)
   .command('start', 'start a farming node')
   .command('stop', 'stop a farming node')
   .command('restart', 'restart a farming node')


### PR DESCRIPTION
Hello colleagues

Maybe I made errors with work in github, but please write comments about my pull request.

Part bash script for check status storj nodes

```bash
x=`storjshare -V`
echo $x
```

When I started bash script, I saw echo output

```bash
storjshare-create.js storjshare-daemon.js storjshare-destroy.js storjshare.js storjshare-killall.js storjshare-load.js storjshare-logs.js storjshare-restart.js storjshare-save.js storjshare-start.js storjshare-status.js storjshare-stop.js daemon: 2.5.4, core: 6.4.2, protocol: 1.1.0
```bash

All files in current folder!

But I need only version daemon & core version & protocol version

Because javascript include '*', I saw all files in current folder and required data (daemon/core/protocol version)
 
```bash
.version(`\n  * daemon: ${version}, core: ${core}, protocol: ${protocol}`)
```

This problem can resolve in bash script

```bash
x=`storjshare -V | tr -d '*'`
echo $x
```

or javascript

```javascript
.version(`daemon: ${version}, core: ${core}, protocol: ${protocol}`)
```

This problem can meet with junior users in bash scripting.