### PR TITLE
bugfix fd-diskspace allow dot on osx and linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "dnode": "^1.2.2",
     "du": "^0.1.0",
     "editor": "^1.0.0",
-    "fd-diskspace": "git+https://github.com/littleskunk/fd-diskspace#2866a4cf147649d97f81fb33464bcbf0f8176bd5",
+    "fd-diskspace": "git+https://github.com/littleskunk/fd-diskspace#c339b792a3fa7b6bb3af6f004b9873f270ce729b",
     "kad-logger-json": "^0.1.2",
     "mkdirp": "^0.5.1",
     "pretty-ms": "^2.1.0",


### PR DESCRIPTION
* Closes https://github.com/Storj/storjshare-daemon/issues/144