### PR TITLE
use the git tag as the version for the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: storjshare
-version: 3.1.0
+version: git
 summary: farm data on the Storj network.
 description: |
   Earn money by sharing your hard drive space.


### PR DESCRIPTION
A recent snapcraft update lets you use the git revision as the version. If the snap is built from an annotated tag, that tag will be the version.