### PR TITLE
Allow snap app to access $HOME directory.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 apps:
   storjshare:
     command: storjshare
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, home]
 
 parts:
   storjshare-daemon:


### PR DESCRIPTION
New configuration will be created under /home/$user/snap/storjshare/...

The plug interface will make sure the app are able to access the config file in user directory else user have to use --devmode when install the snap.