### PR TITLE
Ease-of-Use improvements in daemon

### DIFF
--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -35,7 +35,7 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
         head: ['cyan', 'bold'],
         border: []
       },
-      colWidths: [45, 15, 10, 10, 10, 11, 10]
+      colWidths: [45, 10, 10, 10, 10, 11, 10]
     });
     shares.forEach((share) => {
       let status = '?';

--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -26,6 +26,14 @@ function getColoredValue(status, value) {
   }
 }
 
+function fixContractValue(contractCount) {
+  contractCount = contractCount || 0;
+  if (contractCount > 99999999) {
+    return '>99999999';
+  }
+  return contractCount;
+}
+
 utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
   rpc.status(function(err, shares) {
     let table = new Table({
@@ -63,10 +71,7 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
       let ntpStatus = getColoredValue(share.meta.farmerState.ntpStatus.status,
         share.meta.farmerState.ntpStatus.delta);
       
-      let contracts = share.meta.farmerState.contractCount || 0;
-      if (contracts > 99999999) {
-        contracts = ">99999999";
-      }
+      let contracts = fixContractValue(share.meta.farmerState.contractCount);
 
       table.push([
         `${share.id}\n  → ${share.config.storagePath}`,

--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -14,8 +14,7 @@ storjshare_status
   .parse(process.argv);
 
 function portStatusInitialized(portStatus) {
-  return portStatus.isPublic !== undefined
-    && portStatus.uPnP !== undefined
+  return portStatus.uPnP !== undefined
     && portStatus.portOpen !== undefined;
 }
 
@@ -47,7 +46,7 @@ function getConnectionType(portStatus) {
   else if (portStatus.tunneled) {
     connectionType = '(Tunnel)';
   }
-  else if (!portStatus.uPnP && !portStatus.isPublic) {
+  else if (!portStatus.uPnP && !portStatus.publicIp) {
     connectionType = '(Private)';
   }
   else {

--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -35,7 +35,7 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
         head: ['cyan', 'bold'],
         border: []
       },
-      colWidths: [45, 10, 10, 10, 10, 8, 11, 10]
+      colWidths: [45, 10, 10, 10, 10, 9, 11, 10]
     });
     shares.forEach((share) => {
       let status = '?';

--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -13,15 +13,59 @@ storjshare_status
   .description('prints the status of all managed shares')
   .parse(process.argv);
 
+function portStatusInitialized(portStatus) {
+  return portStatus.isPublic !== undefined
+    && portStatus.uPnP !== undefined
+    && portStatus.portOpen !== undefined;
+}
+
+function getPortValueColored(portStatus, value) {
+  if (portStatus.portOpen) {
+    return colors.green(value);
+  }
+  if (portStatus.tunneled) {
+    return colors.yellow(value);
+  }
+  return colors.red(value);
+}
+
+function getPort(portStatus) {
+  if (portStatusInitialized(portStatus)) {
+    return getPortValueColored(portStatus,portStatus.listenPort);
+  }
+  return '...';
+}
+
+function getConnectionType(portStatus) {
+  let connectionType = '';
+  if (!portStatusInitialized(portStatus)) {
+    return connectionType;
+  }
+  if (portStatus.portOpen) {
+    connectionType = portStatus.uPnP ? '(uPnP)' : '(TCP)';
+  }
+  else if (portStatus.tunneled) {
+    connectionType = '(Tunnel)';
+  }
+  else if (!portStatus.uPnP && !portStatus.isPublic) {
+    connectionType = '(Private)';
+  }
+  else {
+    connectionType = '(Closed)';
+  }
+  return getPortValueColored(portStatus,connectionType);
+}
+
 utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
   rpc.status(function(err, shares) {
     let table = new Table({
-      head: ['Share', 'Status', 'Uptime', 'Restarts', 'Peers', 'Shared'],
+      head: ['Share', 'Status', 'Uptime', 'Restarts', 'Peers',
+        'Port', 'Shared'],
       style: {
         head: ['cyan', 'bold'],
         border: []
       },
-      colWidths: [45, 10, 10, 10, 10, 10]
+      colWidths: [45, 15, 10, 10, 10, 11, 10]
     });
     shares.forEach((share) => {
       let status = '?';
@@ -40,12 +84,15 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
           status = 'unknown';
       }
 
+      let portStatus = share.meta.farmerState.portStatus;
+
       table.push([
         `${share.id}\n  → ${share.config.storagePath}`,
         status,
         prettyMs(share.meta.uptimeMs),
         share.meta.numRestarts || 0,
         share.meta.farmerState.totalPeers || 0,
+        getPort(portStatus) + '\n' + getConnectionType(portStatus),
         share.meta.farmerState.spaceUsed + '\n' +
           `(${share.meta.farmerState.percentUsed}%)`
       ]);

--- a/script/farmer.js
+++ b/script/farmer.js
@@ -18,7 +18,7 @@ let farmerState = {
   lastActivity: Date.now(),
   portStatus: {
     listenPort: 0,
-    isPublic: null,
+    publicIp: null,
     uPnP: null,
     tunneled: null,
     portOpen: null
@@ -49,7 +49,7 @@ farmer.join((err) => {
 function updatePortStatus() {
   farmerState.portStatus.uPnP = farmer.transport._requiresTraversal;
   farmerState.portStatus.listenPort = farmer.transport._contact.port;
-  farmerState.portStatus.isPublic = farmer.transport._isPublic;
+  farmerState.portStatus.publicIp = farmer.transport._publicIp || false;
   farmerState.portStatus.portOpen = farmer.transport._portOpen;
   farmerState.portStatus.tunneled = farmer._tunneled || false;
 }

--- a/script/farmer.js
+++ b/script/farmer.js
@@ -135,11 +135,11 @@ function updateNtpDelta() {
     }
     else {
       farmerState.ntpStatus.delta = delta + 'ms';
-      if (delta <= 50) {
-        farmerState.ntpStatus.status = 0;
+      if (delta > 9999 || delta < -9999) {
+        farmerState.ntpStatus.delta = '>9999ms';
       }
-      else if (delta <= 100) {
-        farmerState.ntpStatus.status = 1;
+      if (delta <= 500 && delta >= -500) {
+        farmerState.ntpStatus.status = 0;
       }
       else {
         farmerState.ntpStatus.status = 2;

--- a/script/farmer.js
+++ b/script/farmer.js
@@ -15,7 +15,14 @@ let farmerState = {
   percentUsed: '...',
   spaceUsed: '...',
   totalPeers: 0,
-  lastActivity: Date.now()
+  lastActivity: Date.now(),
+  portStatus: {
+    listenPort: 0,
+    isPublic: null,
+    uPnP: null,
+    tunneled: null,
+    portOpen: null
+  }
 };
 
 config.keyPair = new storj.KeyPair(config.networkPrivateKey);
@@ -39,7 +46,16 @@ farmer.join((err) => {
   }
 });
 
+function updatePortStatus() {
+  farmerState.portStatus.uPnP = farmer.transport._requiresTraversal;
+  farmerState.portStatus.listenPort = farmer.transport._contact.port;
+  farmerState.portStatus.isPublic = farmer.transport._isPublic;
+  farmerState.portStatus.portOpen = farmer.transport._portOpen;
+  farmerState.portStatus.tunneled = farmer._tunneled || false;
+}
+
 function sendFarmerState() {
+  updatePortStatus();
   farmerState.totalPeers = farmer.router.length;
   process.send(farmerState);
 }


### PR DESCRIPTION
This is to implement https://github.com/Storj/storjshare-gui/issues/513

- [x] Show port status
- [x] Show NTP delta and refresh periodically
- [x] Show contract (accepted offer) count

Use the values provided by farmer to determine port and connection type and display when user runs storjshare status

Requires https://github.com/Storj/core/pull/701 be merged.

![storj-cli](https://user-images.githubusercontent.com/1991399/27239205-f65e8d8a-529d-11e7-9d1d-1b5ec6aba09d.png)
