### PR TITLE
Add maxShardSize option

### DIFF
--- a/script/farmer.js
+++ b/script/farmer.js
@@ -20,6 +20,7 @@ let farmerState = {
 
 config.keyPair = new storj.KeyPair(config.networkPrivateKey);
 config.logger = new Logger(config.loggerVerbosity);
+config.maxShardSize = config.maxShardSize ? bytes.parse(config.maxShardSize) : null;
 config.storageManager = new storj.StorageManager(
   new storj.EmbeddedStorageAdapter(config.storagePath),
   {


### PR DESCRIPTION
This PR will add the conversion of an optional config field `maxShardSize` from human readable values like 100MB to bytes.
This allows each node to not respond with storage offers to contracts with a higher shard size than the configured one in the config.
Requires https://github.com/Storj/core/pull/702 to be merged to work, but can be merged before, it wont do harm ;)