### PR TITLE
Fix BTC to ERC20 in sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,14 +250,14 @@ information and go on with Step 1 and 2.
   "tabs": [
     {
       "key": "4154e85e87b323611cba45ab1cd51203f2508b1da8455cdff8b641cce827f3d6",
-      "address": "1K1rPg...",
+      "address": "0xfB691...",
       "storage": {
         "dataDir": "D:\\Storj\\storjshare-5f4722"
       }
     },
     {
       "key": "0b0341a9913bb84b51485152a1b0a8a6ed68fa4f9a4fedb26c61ff778ce61ec8",
-      "address": "1K1rPg...",
+      "address": "0xfB691...",
       "storage": {
         "dataDir": "D:\\Storj\\storjshare-48a1c4"
       }
@@ -302,7 +302,7 @@ Now that you have Storj Share installed, use the `create` command to generate
 your configuration.
 
 ```
-storjshare create --key 4154e8... --storj 1K1rPg... --storage <datadir> -o <writepath>
+storjshare create --key 4154e8... --storj 0xfB691... --storage <datadir> -o <writepath>
 ```
 
 This will generate your configuration file given the parameters you passed in,

--- a/bin/storjshare-create.js
+++ b/bin/storjshare-create.js
@@ -51,7 +51,8 @@ if (!storjshare_create.storj) {
 }
 
 if (!utils.isValidEthereumAddress(storjshare_create.storj)) {
-  console.error('\n SJCX addresses are no longer supported. Please enter ERC20 compatible ETH wallet address');
+  console.error('\n SJCX addresses are no longer supported. \
+Please enter ERC20 compatible ETH wallet address');
   process.exit(1);
 }
 

--- a/bin/storjshare-create.js
+++ b/bin/storjshare-create.js
@@ -12,6 +12,7 @@ const mkdirp = require('mkdirp');
 const stripJsonComments = require('strip-json-comments');
 const storjshare_create = require('commander');
 const {execSync} = require('child_process');
+const utils = require('../lib/utils');
 
 const defaultConfig = JSON.parse(stripJsonComments(fs.readFileSync(
   path.join(__dirname, '../example/farmer.config.json')
@@ -46,6 +47,11 @@ storjshare_create
 
 if (!storjshare_create.storj) {
   console.error('\n  no payment address was given, try --help');
+  process.exit(1);
+}
+
+if (!utils.isValidEthereumAddress(storjshare_create.storj)) {
+  console.error('\n SJCX addresses are no longer supported. Please enter ERC20 compatible ETH wallet address');
   process.exit(1);
 }
 

--- a/example/farmer.config.json
+++ b/example/farmer.config.json
@@ -1,5 +1,5 @@
 {
-  // Set the STORJ/BTC address for receiving contract payments
+  // Set the STORJ/ERC20 wallet address for receiving contract payments
   "paymentAddress": "",
   // Subscribes to the given contract topics
   // See https://storj.github.io/core/tutorial-contract-topics.html


### PR DESCRIPTION
The sample config and daemon options were updated to specifiy STORJ instead of SJCX but the "BTC" in the sample config file was not updated to reflect that STORJ is an ERC20 token.