### PR TITLE
Add util method portIsAvailable

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,6 +160,29 @@ exports.getFreeSpace = function(path, callback) {
 };
 
 /**
+ * Checks whether a port is currently in use or open
+ * Callback is of form (err, result)
+ * @param {Number} port
+ */
+exports.portIsOpen = function(port, callback) {
+  let testServer = net.createServer()
+  .once('error', function(err) {
+    if(err.code === 'EADDRINUSE') {
+      callback(null, false);
+    } else {
+      callback(err);
+    }
+  })
+  .once('listening', function() {
+    testServer.once('close', function() {
+      callback(null, true);
+    })
+    .close();
+  })
+  .listen(port);
+};
+
+/**
  * Checks the status of the daemon RPC server
  * @param {Number} port
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,7 +164,7 @@ exports.getFreeSpace = function(path, callback) {
  * Callback is of form (err, result)
  * @param {Number} port
  */
-exports.portIsOpen = function(port, callback) {
+exports.portIsAvailable = function(port, callback) {
   if(typeof port !== 'number' || port < 0 || port > 65535) {
     return callback('Invalid port');
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -163,18 +163,21 @@ exports.getFreeSpace = function(path, callback) {
  * Checks whether a port is currently in use or open
  * Callback is of form (err, result)
  * @param {Number} port
+ * @param {Function} callback
  */
 exports.portIsAvailable = function(port, callback) {
   if(typeof port !== 'number' || port < 0 || port > 65535) {
     return callback('Invalid port');
+  } else if (port <= 1024) {
+    return callback(
+      'Using a port in the well-known range is strongly discouraged');
   }
   let testServer = net.createServer()
-  .once('error', function(err) {
-    if(err.code === 'EADDRINUSE') {
+  .once('error', function() {
+    testServer.once('close', function() {
       callback(null, false);
-    } else {
-      callback(err);
-    }
+    })
+    .close();
   })
   .once('listening', function() {
     testServer.once('close', function() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -165,6 +165,9 @@ exports.getFreeSpace = function(path, callback) {
  * @param {Number} port
  */
 exports.portIsOpen = function(port, callback) {
+  if(typeof port !== 'number' || port < 0 || port > 65535) {
+    return callback('Invalid port');
+  }
   let testServer = net.createServer()
   .once('error', function(err) {
     if(err.code === 'EADDRINUSE') {

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -5,6 +5,7 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const {expect} = require('chai');
 const {EventEmitter} = require('events');
+const net = require('net');
 
 describe('module:utils', function() {
 
@@ -173,6 +174,52 @@ describe('module:utils', function() {
         expect(err.message).to.equal('Invalid storage size');
         done();
       });
+    });
+
+  });
+
+  describe('#portIsAvailable', function() {
+
+    it('should callback error if argument is not a valid port', function(done) {
+      utils.portIsAvailable('Not a port number', function(err, result) {
+        expect(err).to.equal('Invalid port');
+        expect(result).to.equal(undefined);
+        done();
+      });
+    });
+
+    it('should callback error if port is in well-known range', function(done) {
+      utils.portIsAvailable(77, function(err, result) {
+        expect(err).to.equal(
+          'Using a port in the well-known range is strongly discouraged');
+        done();
+        expect(result).to.equal(undefined);
+      });
+    });
+
+    it('should hopefully return true on this semi-random port', function(done) {
+      utils.portIsAvailable(17026, function(err, result) {
+        expect(err).to.equal(null);
+        expect(result).to.equal(true);
+        done();
+      });
+    });
+
+    it('should return false on a port already in use', function(done) {
+      const server = net.createServer();
+      server.once('error', function(err) {
+        done(err);
+      })
+      .once('listening', function() {
+        utils.portIsAvailable(17027, function(err, result) {
+          expect(err).to.equal(null);
+          expect(result).to.equal(false);
+          server.once('close', function() {
+            done();
+          }).close();
+        });
+      })
+      .listen(17027);
     });
 
   });


### PR DESCRIPTION
This method will allow completion of [issue #577 in storjshare-gui](https://github.com/Storj/storjshare-gui/issues/577) by providing the gui with a method to check whether or not a port is open. This method is to be used sparingly as it could take a second or two for node to spin up a server, and should only be used as a final check before the user leaves that page of the wizard. I will add features to the gui necessary to convey that the program is validating a port.