### PR TITLE
Disallow contract and owner addresses

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,15 @@ exports._isValidPayoutAddress = function(address) {
  * @param {String} address
  */
 exports.isValidEthereumAddress = function(address) {
+  //Disallow contract and contract owner addresses
+  //Stops users from accidentally copying the wrong address
+  const disallowAddresses = [
+    '0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac',
+    '0x00f6bf3c5033e944feddb3dc8ffb4d47af17ef0b'
+  ];
   if (typeof address !== 'string') {
+    return false;
+  } else if (disallowAddresses.indexOf(address.toLowerCase()) >= 0) {
     return false;
   }
   return /^0x([0-9A-Fa-f]{2}){20}$/.test(address);

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -44,6 +44,18 @@ describe('module:utils', function() {
       )).to.equal(false);
     });
 
+    it('should return false for contract address', function() {
+      expect(utils.isValidEthereumAddress(
+        '0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac'
+      )).to.equal(false);
+    });
+
+    it('should return false for contract owner address', function() {
+      expect(utils.isValidEthereumAddress(
+        '0x00f6bf3c5033e944feddb3dc8ffb4d47af17ef0b'
+      )).to.equal(false);
+    });
+
   });
 
   describe('#_isValidDirectory', function() {


### PR DESCRIPTION
Since users can sometimes copy the wrong address, especially if they are new to the technology, we want to stop them in case they accidentally copy the contract or contract owner addresses. They should not be allowed to farm on these because they won't receive the proceeds from their farming, and there has been a problem in the past with people farming to the SJCX owner address.