### PR TITLE
Add hostname:port option

### DIFF
--- a/bin/storjshare-daemon.js
+++ b/bin/storjshare-daemon.js
@@ -14,6 +14,8 @@ const storjshare_daemon = require('commander');
 storjshare_daemon
   .option('--status', 'print the status of the daemon and exit')
   .option('-F, --foreground', 'keeps the process in the foreground')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
 const api = new RPC({
@@ -26,7 +28,16 @@ function startDaemonRpcServer() {
     .listen(config.daemonRpcPort, config.daemonRpcAddress);
 }
 
-utils.checkDaemonRpcStatus(config.daemonRpcPort, (isRunning) => {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_daemon.remote) {
+  address = storjshare_daemon.remote.split(':')[0];
+  if (storjshare_daemon.remote.split(':').length > 1) {
+    port = parseInt(storjshare_daemon.remote.split(':')[1], 10);
+  }
+}
+
+utils.checkDaemonRpcStatus(port, (isRunning) => {
   if (storjshare_daemon.status) {
     console.info(`\n  * daemon ${isRunning ? 'is' : 'is not'} running`);
     process.exitCode = isRunning ? 0 : 3;
@@ -44,4 +55,4 @@ utils.checkDaemonRpcStatus(config.daemonRpcPort, (isRunning) => {
       startDaemonRpcServer();
     }
   }
-});
+}, address);

--- a/bin/storjshare-destroy.js
+++ b/bin/storjshare-destroy.js
@@ -9,6 +9,8 @@ const storjshare_destroy = require('commander');
 storjshare_destroy
   .description('stops a running share and removes it from status')
   .option('-i, --nodeid <nodeid>', 'id of the managed share')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
 if (!storjshare_destroy.nodeid) {
@@ -16,7 +18,16 @@ if (!storjshare_destroy.nodeid) {
   process.exit(1);
 }
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_destroy.remote) {
+  address = storjshare_destroy.remote.split(':')[0];
+  if (storjshare_destroy.remote.split(':').length > 1) {
+    port = parseInt(storjshare_destroy.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   rpc.destroy(storjshare_destroy.nodeid, (err) => {
     if (err) {
       console.error(`\n  cannot destroy node, reason: ${err.message}`);
@@ -25,4 +36,4 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
     console.info(`\n  * share ${storjshare_destroy.nodeid} destroyed`);
     sock.end();
   });
-});
+}, address);

--- a/bin/storjshare-killall.js
+++ b/bin/storjshare-killall.js
@@ -8,9 +8,20 @@ const storjshare_killall = require('commander');
 
 storjshare_killall
   .description('destroys all running shares and stop daemon')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_killall.remote) {
+  address = storjshare_killall.remote.split(':')[0];
+  if (storjshare_killall.remote.split(':').length > 1) {
+    port = parseInt(storjshare_killall.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   sock.on('end', () => console.info('\n  * daemon has stopped'));
   rpc.killall(() => sock.end());
-});
+}, address);

--- a/bin/storjshare-load.js
+++ b/bin/storjshare-load.js
@@ -11,6 +11,8 @@ const storjshare_load = require('commander');
 storjshare_load
   .description('loads a snapshot of shares and starts all of them')
   .option('-s, --snapshot <path>', 'path to load the snapshot file')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
 if (!storjshare_load.snapshot) {
@@ -25,7 +27,16 @@ if (!path.isAbsolute(storjshare_load.snapshot)) {
                                        storjshare_load.snapshot);
 }
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_load.remote) {
+  address = storjshare_load.remote.split(':')[0];
+  if (storjshare_load.remote.split(':').length > 1) {
+    port = parseInt(storjshare_load.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   rpc.load(storjshare_load.snapshot, (err) => {
     if (err) {
       console.error(`\n  cannot load snapshot, reason: ${err.message}`);
@@ -34,4 +45,4 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
     console.info(`\n  * snapshot ${storjshare_load.snapshot} loaded`);
     sock.end();
   });
-});
+}, address);

--- a/bin/storjshare-logs.js
+++ b/bin/storjshare-logs.js
@@ -15,6 +15,8 @@ storjshare_logs
   .description('tails the logs for the given share id')
   .option('-i, --nodeid <nodeid>', 'id of the running share')
   .option('-l, --lines <num>', 'lines back to print')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
 if (!storjshare_logs.nodeid) {
@@ -68,7 +70,16 @@ function prettyLog(line) {
   console.log(output);
 }
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_logs.remote) {
+  address = storjshare_logs.remote.split(':')[0];
+  if (storjshare_logs.remote.split(':').length > 1) {
+    port = parseInt(storjshare_logs.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   process.on('exit', () => {
     sock.end();
     process.exit(0);
@@ -128,4 +139,4 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
     }, 1000);
 
   });
-});
+}, address);

--- a/bin/storjshare-restart.js
+++ b/bin/storjshare-restart.js
@@ -10,6 +10,8 @@ storjshare_restart
   .description('restarts the running share specified')
   .option('-i, --nodeid <nodeid>', 'id of the running share')
   .option('-a, --all', 'restart all running shares')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
 if (!storjshare_restart.nodeid && !storjshare_restart.all) {
@@ -17,7 +19,16 @@ if (!storjshare_restart.nodeid && !storjshare_restart.all) {
   process.exit(1);
 }
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_restart.remote) {
+  address = storjshare_restart.remote.split(':')[0];
+  if (storjshare_restart.remote.split(':').length > 1) {
+    port = parseInt(storjshare_restart.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   if (storjshare_restart.all) {
     console.info('\n  * restarting all managed shares');
   }
@@ -36,4 +47,4 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
 
     sock.end();
   });
-});
+}, address);

--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -11,9 +11,20 @@ const storjshare_status = require('commander');
 
 storjshare_status
   .description('prints the status of all managed shares')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_status.remote) {
+  address = storjshare_status.remote.split(':')[0];
+  if (storjshare_status.remote.split(':').length > 1) {
+    port = parseInt(storjshare_status.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   rpc.status(function(err, shares) {
     let table = new Table({
       head: ['Share', 'Status', 'Uptime', 'Restarts', 'Peers', 'Shared'],
@@ -53,4 +64,4 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
     console.log('\n' + table.toString());
     sock.end();
   });
-});
+}, address);

--- a/bin/storjshare-stop.js
+++ b/bin/storjshare-stop.js
@@ -9,6 +9,8 @@ const storjshare_stop = require('commander');
 storjshare_stop
   .description('stops the running share specified')
   .option('-i, --nodeid <nodeid>', 'id of the running share')
+  .option('-r, --remote <hostname:port>',
+    'hostname and optional port of the daemon')
   .parse(process.argv);
 
 if (!storjshare_stop.nodeid) {
@@ -16,7 +18,16 @@ if (!storjshare_stop.nodeid) {
   process.exit(1);
 }
 
-utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
+let port = config.daemonRpcPort;
+let address = null;
+if (storjshare_stop.remote) {
+  address = storjshare_stop.remote.split(':')[0];
+  if (storjshare_stop.remote.split(':').length > 1) {
+    port = parseInt(storjshare_stop.remote.split(':')[1], 10);
+  }
+}
+
+utils.connectToDaemon(port, function(rpc, sock) {
   rpc.stop(storjshare_stop.nodeid, (err) => {
     if (err) {
       console.error(`\n  cannot stop node, reason: ${err.message}`);
@@ -25,4 +36,4 @@ utils.connectToDaemon(config.daemonRpcPort, function(rpc, sock) {
     console.info(`\n  * share ${storjshare_stop.nodeid} stopped`);
     return sock.end();
   });
-});
+}, address);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,9 +162,14 @@ exports.getFreeSpace = function(path, callback) {
 /**
  * Checks the status of the daemon RPC server
  * @param {Number} port
+ * @param {Function} callback
+ * @param {String} hostname - optional
  */
-exports.checkDaemonRpcStatus = function(port, callback) {
-  const sock = net.connect(port);
+exports.checkDaemonRpcStatus = function(port, callback, hostname = null) {
+  if (!hostname) {
+    hostname = '127.0.0.1';
+  }
+  const sock = net.connect(port, hostname);
 
   sock.once('error', function() {
     callback(false);
@@ -180,9 +185,13 @@ exports.checkDaemonRpcStatus = function(port, callback) {
  * Connects to the daemon and callback with rpc
  * @param {Number} port
  * @param {Function} callback
+ * @param {String} hostname - optional
  */
-exports.connectToDaemon = function(port, callback) {
-  const sock = dnode.connect(port);
+exports.connectToDaemon = function(port, callback, hostname = null) {
+  if (!hostname) {
+    hostname = '127.0.0.1';
+  }
+  const sock = dnode.connect(hostname, port);
 
   sock.on('error', function() {
     process.exitCode = 1;


### PR DESCRIPTION
This PR will add the optional cli option `-r, --remote <hostname:port>  hostname and optional port of the daemon`. This allows the storjshare-daemon commands to be executed on a remote storjshare-daemon whos rpcPort is reachable. The util method `connectToDaemon` and `checkDaemonRpcStatus` have been modified to support a third optional argument, the hostname. If nothing has been entered, hostname will default to `127.0.0.1` as it did implicitly before and port will default to `config.daemonRpcPort` as before.

The main reason for this is to manage docker instances more easily, but it can be used for non-local machines as well.