### PR TITLE
[Docs] Add 'connecting to a remote Daemon' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,34 @@ storjshare killall
 storjshare daemon --foreground
 ```
 
+## Connecting to a remote Daemon
+
+**Note: Exposing your storjshare-daemon to the Internet is a bad idea
+as everybody could read your Private Key!**
+
+To connect to a remote running daemon instance you will first need to
+ensure this daemon is running on a different address than the default
+`127.0.0.1`. This can be achieved by [configuring the Daemon](#configuring-the-daemon).
+
+After your storjshare-daemon is reachable (eg. within your home network)
+you can use `-r` or `--remote` option (on supported commands) to use the
+specified IP/hostname and port to connect to, instead of `127.0.0.1`.
+
+**Note that this option does not support to start the storjshare-daemon
+on a different system, only connect to an already running one!**
+
+Example to connect to remote daemon running on `192.168.0.10` on the default port (`45015`) and show the status:
+
+```
+storjshare status --remote 192.168.0.10
+```
+
+If the port is changed, just append it like so:
+
+```
+storjshare status --remote 192.168.0.10:51000
+```
+
 ## Migrating from [`storjshare-gui`](https://github.com/storj/storjshare-gui) or [`storjshare-cli`](https://github.com/storj/storjshare-cli)
 #### storjshare-gui
 If you are using the `storjshare-gui` package you can go on with the latest

--- a/bin/storjshare-daemon.js
+++ b/bin/storjshare-daemon.js
@@ -15,7 +15,8 @@ storjshare_daemon
   .option('--status', 'print the status of the daemon and exit')
   .option('-F, --foreground', 'keeps the process in the foreground')
   .option('-r, --remote <hostname:port>',
-    'hostname and optional port of the daemon')
+    'hostname and optional port of the daemon ' +
+    'to connect to when using --status')
   .parse(process.argv);
 
 const api = new RPC({


### PR DESCRIPTION
This PR will add some basic 'getting started' to README on how to connect to a remote running daemon.  
I also made sure to stress that the daemon should not run on a public address ;)  
It also clarifies that this option does not allow you to start the daemon on a remote computer, it only connects to already running daemons. The last part also has been added to the cli help text.