### PR TITLE
Fix port status to not show red if unable to determine if port is open

### DIFF
--- a/script/farmer.js
+++ b/script/farmer.js
@@ -86,8 +86,8 @@ function getConnectionStatus() {
   if (farmer._tunneled) {
     return 1;
   }
-  if (!farmer._requiresTraversal
-    && !farmer.transport_publicIP) {
+  if (!farmer.transport._requiresTraversal
+    && !farmer.transport._publicIp) {
       return 2;
   }
   return -1;

--- a/script/farmer.js
+++ b/script/farmer.js
@@ -66,9 +66,6 @@ function getConnectionType() {
   if(!transportInitialized()) {
     return '';
   }
-  if (farmer.transport._portOpen) {
-    return farmer.transport._requiresTraversal ? '(uPnP)' : '(TCP)';
-  }
   if (farmer._tunneled) {
     return '(Tunnel)';
   }
@@ -76,7 +73,7 @@ function getConnectionType() {
     && !farmer.transport._publicIp) {
     return '(Private)';
   }
-  return '(Closed)';
+  return farmer.transport._requiresTraversal ? '(uPnP)' : '(TCP)';
 }
 
 function getConnectionStatus() {
@@ -89,7 +86,11 @@ function getConnectionStatus() {
   if (farmer._tunneled) {
     return 1;
   }
-  return 2;
+  if (!farmer._requiresTraversal
+    && !farmer.transport_publicIP) {
+      return 2;
+  }
+  return -1;
 }
 
 function sendFarmerState() {


### PR DESCRIPTION
Workaround for https://github.com/Storj/core/issues/703

When NAT reflection is disabled we can't tell if a port is truly closed or if we simply are not able to loopback. If this is the case, don't show the port as red & closed, simply do not color green.