### PR TITLE
[WIP] Repair config on read

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -65,6 +65,8 @@ class RPC {
       throw new Error(`failed to parse config at ${configPath}`);
     }
 
+    utils.repairConfig(config);
+
     try {
       utils.validate(config);
     } catch (err) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -65,7 +65,7 @@ class RPC {
       throw new Error(`failed to parse config at ${configPath}`);
     }
 
-    utils.repairConfig(config);
+    config = utils.repairConfig(config);
 
     try {
       utils.validate(config);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,7 +56,9 @@ exports._isValidDirectory = function(directory) {
  * @param {String} size
  */
 exports._isValidSize = function(size) {
-  return Number(size) >= 0 && typeof size !== 'undefined';
+  return typeof size === 'number'
+    && size >= 0
+    && size <= 8e+12; // 8TB
 };
 
 /**
@@ -71,6 +73,18 @@ exports.validate = function(config) {
          'Invalid storage size');
   assert(this._isValidDirectory(config.storagePath),
          'Could not create Shard Directory');
+};
+
+/**
+ * Attempts to apply common fixes to a config
+ * @param {Object} config
+ */
+exports.repairConfig = function(config) {
+  // Check to see if the size is not using a storage unit
+  if(!isNaN(parseInt(config.storageAllocation))
+    && this._isValidSize(config.storageAllocation)) {
+      config.storageAllocation = config.storageAllocation.toString() + 'B';
+  }
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,6 +85,7 @@ exports.repairConfig = function(config) {
     && this._isValidSize(config.storageAllocation)) {
       config.storageAllocation = config.storageAllocation.toString() + 'B';
   }
+    return config;
 };
 
 /**

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -126,6 +126,18 @@ describe('module:utils', function() {
 
   });
 
+  describe('#repairConfig', function() {
+
+    it('should convert an unspecified size to bytes', function() {
+      let dummyConfig = {
+        storageAllocation: 1048576
+      };
+      utils.repairConfig(dummyConfig);
+      expect(dummyConfig.storageAllocation).to.equal('1048576B');
+    });
+
+  });
+
   describe('#validateAllocation', function() {
 
     it('should callback null if valid', function(done) {


### PR DESCRIPTION
- Fix the `_isValidSize()` function to be more correct
- If the `storageAllocation` doesn't have a size specifier, default to bytes and add `B` to the end of the value. This could be left over from older configs.