### PR TITLE
Resolve storjshare status share truncated.

### DIFF
--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -109,7 +109,7 @@ utils.connectToDaemon(port, function(rpc, sock) {
           head: ['cyan', 'bold'],
           border: []
         },
-        colWidths: [45, 9, 10, 10, 9, 15, 9, 10, 9]
+        colWidths: [45, 9, 10, 10, 9, 15, 9, 10, 11]
       });
       shares.forEach((share) => {
         let status = '?';


### PR DESCRIPTION
Seems like an easy but effective fix (Although another option is to look at truncating the decimal places before the unit type - this is only 2 characters more)
This is enough for 4 characters (e.g 1023), the dot and 2 decimal places before the unit type (MB, GB etc).
Resolves https://github.com/Storj/storjshare-daemon/issues/124