### PR TITLE
Fix storjshare status --json response to be valid

### DIFF
--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -91,7 +91,7 @@ function prepareJson(shares) {
     json[i].sharedPercent = share.meta.farmerState.percentUsed;
   }
 
-  return json;
+  return JSON.stringify(json);
 }
 
 utils.connectToDaemon(port, function(rpc, sock) {


### PR DESCRIPTION
Now valid json. Fix as per :https://github.com/Storj/storjshare-daemon/issues/213
Tested locally and output validated with https://jsonlint.com.

Fix suggestion originanlly by @buckley310