### PR TITLE
Add ignoreFreeSpaceCheck config option

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,7 +90,7 @@ exports.validateAllocation = function(conf, callback) {
     conf.storageAllocation = conf.storageAllocation.toString() + 'B';
   }
 
-  if (!(ignoreFreeSpaceCheck in conf) || !conf.ignoreFreeSpaceCheck) {
+  if (!("ignoreFreeSpaceCheck" in conf) || !conf.ignoreFreeSpaceCheck) {
     self.getFreeSpace(conf.storagePath, function(err, free) {
       var allocatedSpace = bytes.parse(conf.storageAllocation);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,22 +90,28 @@ exports.validateAllocation = function(conf, callback) {
     conf.storageAllocation = conf.storageAllocation.toString() + 'B';
   }
 
-  self.getFreeSpace(conf.storagePath, function(err, free) {
-    var allocatedSpace = bytes.parse(conf.storageAllocation);
+  if (!(ignoreFreeSpaceCheck in conf) || !conf.ignoreFreeSpaceCheck) {
+    self.getFreeSpace(conf.storagePath, function(err, free) {
+      var allocatedSpace = bytes.parse(conf.storageAllocation);
 
-    self.getDirectorySize(conf.storagePath, function(err, usedSpaceBytes) {
-      if (err) {
-        return callback(err);
-      }
+      self.getDirectorySize(conf.storagePath, function(err, usedSpaceBytes) {
+        if (err) {
+          return callback(err);
+        }
 
-      if (allocatedSpace > free + usedSpaceBytes) {
-        return callback(new Error('Invalid storage size: '+
-          -(free + usedSpaceBytes - allocatedSpace) +' bytes missing'));
-      }
+        if (allocatedSpace > free + usedSpaceBytes) {
+          return callback(new Error('Invalid storage size: '+
+            -(free + usedSpaceBytes - allocatedSpace) +' bytes missing'));
+        }
 
-      return callback(null);
+        return callback(null);
+      });
     });
-  });
+  }
+  else
+  {
+    return callback(null);
+  }
 };
 
 /**


### PR DESCRIPTION
Option lets the free disk space check be bypassed if the filesystem doesn't support it properly (like a zfs attached dataset in a FreeBSD jail)