### PR TITLE
Allow nodes with an allocated space size of up to 8TiB.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,7 @@ exports._isValidDirectory = function(directory) {
 exports._isValidSize = function(size) {
   return typeof size === 'number'
     && size >= 0
-    && size <= 8e+12; // 8TB
+    && size <= 8 * Math.pow(2, 30); // 8TiB
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,7 @@ exports._isValidDirectory = function(directory) {
 exports._isValidSize = function(size) {
   return typeof size === 'number'
     && size >= 0
-    && size <= 8 * Math.pow(2, 30); // 8TiB
+    && size <= 8 * Math.pow(2, 40); // 8TiB
 };
 
 /**


### PR DESCRIPTION
"bytes" Node.js module parses "8TB" in the config as 8\*2^40B but the daemon was limited to 8\*10^12B.