### PR TITLE
Remove free + used space check

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,25 +105,7 @@ exports.validateAllocation = function(conf, callback) {
     conf.storageAllocation = conf.storageAllocation.toString() + 'B';
   }
 
-  self.getFreeSpace(conf.storagePath, function(err, free) {
-    var allocatedSpace = bytes.parse(conf.storageAllocation);
-    if (err) {
-      callback(err);
-    }
-
-    self.getDirectorySize(conf.storagePath, function(err, usedSpaceBytes) {
-      if (err) {
-        return callback(err);
-      }
-
-      if (allocatedSpace > free + usedSpaceBytes) {
-        return callback(new Error('Invalid storage size: '+
-          -(free + usedSpaceBytes - allocatedSpace) +' bytes missing'));
-      }
-
-      return callback(null);
-    });
-  });
+  callback(null);
 };
 
 /**

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -160,47 +160,6 @@ describe('module:utils', function() {
       });
     });
 
-    it('should callback error if cannot get size', function(done) {
-      let getFreeSpace = sinon.stub(
-        utils,
-        'getFreeSpace'
-      ).callsArgWith(1, null, 1024);
-      let getDirectorySize = sinon.stub(
-        utils,
-        'getDirectorySize'
-      ).callsArgWith(1, new Error('Failed to get size'));
-      utils.validateAllocation({
-        storageAllocation: '512B',
-        storagePath: 'some/directory/path'
-      }, function(err) {
-        getFreeSpace.restore();
-        getDirectorySize.restore();
-        expect(err.message).to.equal('Failed to get size');
-        done();
-      });
-    });
-
-    it('should callback error if invalid', function(done) {
-      let getFreeSpace = sinon.stub(
-        utils,
-        'getFreeSpace'
-      ).callsArgWith(1, null, 512);
-      let getDirectorySize = sinon.stub(
-        utils,
-        'getDirectorySize'
-      ).callsArgWith(1, null, 512);
-      utils.validateAllocation({
-        storageAllocation: '2048B',
-        storagePath: 'some/directory/path'
-      }, function(err) {
-        getFreeSpace.restore();
-        getDirectorySize.restore();
-        expect(err.message).to.equal(
-          'Invalid storage size: 1024 bytes missing');
-        done();
-      });
-    });
-
   });
 
   describe('#portIsAvailable', function() {


### PR DESCRIPTION
This can also be solved by using `info.free` instead of `info.available`, though this check isn't necessary as there is a free space check before accepting new shards to prevent disk "no space left on device" errors and crashing.

There is a case where `available` will be missing 5% as it is reservered for root user that can lead to an issue where on startup the amount allocated would give an error. This is technically not incorrect.

Thanks @tempestb for helping to debug.
Closes: https://github.com/Storj/storjshare-gui/issues/670