### PR TITLE
Verify checksum of Ethereum payout addresses

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,7 @@ const du = require('du');          // Get amount used
 const disk = require('diskusage'); // Get amount free
 const assert = require('assert');
 const bytes = require('bytes');
+const web3utils = require('web3-utils');
 
 /**
  * Validate the given payout address
@@ -40,7 +41,7 @@ exports.isValidEthereumAddress = function(address) {
   } else if (disallowAddresses.indexOf(address.toLowerCase()) >= 0) {
     return false;
   }
-  return /^0x([0-9A-Fa-f]{2}){20}$/.test(address);
+  return /^0x/.test(address) && web3utils.isAddress(address);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "storj-lib": "^8.0.0",
     "strip-json-comments": "^2.0.1",
     "tail": "^1.2.1",
-    "touch": "3.1.0"
+    "touch": "3.1.0",
+    "web3-utils": "^1.0.0-beta"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -33,10 +33,34 @@ describe('module:utils', function() {
 
   describe('#isValidEthereumAddress', function() {
 
-    it('should return true for valid mainnet', function() {
+    it('should return true for checksumed address', function() {
       expect(utils.isValidEthereumAddress(
         '0xC2D7CF95645D33006175B78989035C7c9061d3F9'
       )).to.equal(true);
+    });
+
+    it('should return true for normalized address', function() {
+      expect(utils.isValidEthereumAddress(
+        '0xc2d7cf95645d33006175b78989035c7c9061d3f9'
+      )).to.equal(true);
+    });
+
+    it('should return true for uppercase address', function() {
+      expect(utils.isValidEthereumAddress(
+        '0xC2D7CF95645D33006175B78989035C7C9061D3F9'
+      )).to.equal(true);
+    });
+
+    it('should return false for invalid checksum', function() {
+      expect(utils.isValidEthereumAddress(
+        '0xC2D7Cf95645D33006175B78989035C7c9061d3F9'
+      )).to.equal(false);
+    });
+
+    it('should return false for public key hash digest', function() {
+      expect(utils.isValidEthereumAddress(
+        'C2D7CF95645D33006175B78989035C7c9061d3F9'
+      )).to.equal(false);
     });
 
     it('should return false for invalid address', function() {


### PR DESCRIPTION
If a payout address uses mixed case, it must be according to [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md).
Only lower- or only uppercase addresses are still valid as well.