### PR TITLE
Fix share status when stopped.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -210,6 +210,27 @@ class RPC {
     }
 
     this.shares.get(nodeId).process.kill('SIGINT');
+
+    //reset share status
+    if (this.shares.has(nodeId)
+      && 'meta' in this.shares.get(nodeId)) {
+      this.shares.get(nodeId).meta.uptimeMs = 0;
+      this.shares.get(nodeId).meta.numRestarts = 0;
+      this.shares.get(nodeId).meta.peers = 0;
+    }
+    if (this.shares.has(nodeId)
+      && 'meta' in this.shares.get(nodeId)
+      && 'farmerState' in this.shares.get(nodeId).meta) {
+      this.shares.get(nodeId).meta.farmerState.bridgesConnectionStatus = 0;
+      this.shares.get(nodeId).meta.farmerState.totalPeers = 0;
+    }
+    if (this.shares.has(nodeId)
+      && 'meta' in this.shares.get(nodeId)
+      && 'farmerState' in this.shares.get(nodeId).meta
+      && 'ntpStatus' in this.shares.get(nodeId).meta.farmerState) {
+      this.shares.get(nodeId).meta.farmerState.ntpStatus.delta = 0;
+    }
+
     setTimeout(() => callback(null), 1000);
   }
   /**

--- a/script/farmer.js
+++ b/script/farmer.js
@@ -66,7 +66,9 @@ farmer.on('bridgeChallenge', (bridge) => {
 farmer.on('bridgesConnected', function() {
   farmerState.bridgesConnectionStatus = 3;
 });
-
+farmer.on('bridgesDisconnected', function() {
+  farmerState.bridgesConnectionStatus = 0;
+});
 
 function transportInitialized() {
   return farmer.transport._requiresTraversal !== undefined

--- a/test/api.unit.js
+++ b/test/api.unit.js
@@ -321,6 +321,47 @@ describe('class:RPC', function() {
       });
     });
 
+
+    it('should reset stoped share status', function (done) {
+      let rpc = new RPC({loggerVerbosity: 0});
+
+      let _proc = {
+        kill: sinon.stub()
+      };
+
+      let meta = {
+        uptimeMs: -1,
+        numRestarts: -1,
+        peers: -1,
+        farmerState: {
+          bridgesConnectionStatus: -1,
+          totalPeers: -1,
+          ntpStatus: {
+            delta: -1
+          }
+        }
+      };
+
+      rpc.shares.set('test', {
+        process: _proc,
+        readyState: 1,
+        meta: meta
+      });
+
+      rpc.stop('test', function () {
+        expect(rpc.shares.get('test').meta.uptimeMs).to.equal(0);
+        expect(rpc.shares.get('test').meta.numRestarts).to.equal(0);
+        expect(rpc.shares.get('test').meta.peers).to.equal(0);
+        expect(rpc.shares.get('test')
+          .meta.farmerState.bridgesConnectionStatus).to.equal(0);
+        expect(rpc.shares.get('test')
+          .meta.farmerState.totalPeers).to.equal(0);
+        expect(rpc.shares.get('test')
+          .meta.farmerState.ntpStatus.delta).to.equal(0);
+        done();
+      });
+    });
+
   });
 
   describe('#restart', function() {


### PR DESCRIPTION
close #281

I reset the share values when the share is stopped to the following:

1. Bridges set to  "disconnected".
2. The delta set to 0.
3. Peers set to 0.
4. Uptime set to 0ms.
5. Restarts count set to 0.

This should also fix similar problems in the GUI.

Here is a screen shot of the fix:
![2017-10-24_23-22-35](https://user-images.githubusercontent.com/10393491/31983994-8eb7c47a-b914-11e7-90d2-ff2398f74770.jpg)