### PR TITLE
Committer: Kevin J Baird <knowledge@storj.io>

### DIFF
--- a/bin/storjshare-create.js
+++ b/bin/storjshare-create.js
@@ -43,11 +43,11 @@ function whichEditor() {
 }
 
 storjshare_create
-  .description('generates a new share configuration')
+  .description('generates a new node configuration')
   .option('--storj <addr>', 'specify the STORJ address (required)')
   .option('--key <privkey>', 'specify the private key')
   .option('--storage <path>', 'specify the storage path')
-  .option('--size <maxsize>', 'specify share size (ex: 10GB, 1TB)')
+  .option('--size <maxsize>', 'specify node size (ex: 10GB, 1TB)')
   .option('--rpcport <port>', 'specify the rpc port number')
   .option('--rpcaddress <addr>', 'specify the rpc address')
   .option('--maxtunnels <tunnels>', 'specify the max tunnels')

--- a/bin/storjshare-destroy.js
+++ b/bin/storjshare-destroy.js
@@ -7,8 +7,8 @@ const utils = require('../lib/utils');
 const storjshare_destroy = require('commander');
 
 storjshare_destroy
-  .description('stops a running share and removes it from status')
-  .option('-i, --nodeid <nodeid>', 'id of the managed share')
+  .description('stops a running node and removes it from status')
+  .option('-i, --nodeid <nodeid>', 'id of the managed node')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')
   .parse(process.argv);

--- a/bin/storjshare-killall.js
+++ b/bin/storjshare-killall.js
@@ -7,7 +7,7 @@ const utils = require('../lib/utils');
 const storjshare_killall = require('commander');
 
 storjshare_killall
-  .description('destroys all running shares and stop daemon')
+  .description('destroys all running nodes and stop daemon')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')
   .parse(process.argv);

--- a/bin/storjshare-load.js
+++ b/bin/storjshare-load.js
@@ -9,7 +9,7 @@ const utils = require('../lib/utils');
 const storjshare_load = require('commander');
 
 storjshare_load
-  .description('loads a snapshot of shares and starts all of them')
+  .description('loads a snapshot of nodes and starts all of them')
   .option('-s, --snapshot <path>', 'path to load the snapshot file')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')

--- a/bin/storjshare-logs.js
+++ b/bin/storjshare-logs.js
@@ -12,8 +12,8 @@ const path = require('path');
 const FsLogger = require('fslogger');
 
 storjshare_logs
-  .description('tails the logs for the given share id')
-  .option('-i, --nodeid <nodeid>', 'id of the running share')
+  .description('tails the logs for the given node id')
+  .option('-i, --nodeid <nodeid>', 'id of the running node')
   .option('-l, --lines <num>', 'lines back to print')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')

--- a/bin/storjshare-restart.js
+++ b/bin/storjshare-restart.js
@@ -7,9 +7,9 @@ const utils = require('../lib/utils');
 const storjshare_restart = require('commander');
 
 storjshare_restart
-  .description('restarts the running share specified')
-  .option('-i, --nodeid <nodeid>', 'id of the running share')
-  .option('-a, --all', 'restart all running shares')
+  .description('restarts the running node specified')
+  .option('-i, --nodeid <nodeid>', 'id of the running node')
+  .option('-a, --all', 'restart all running nodes')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')
   .parse(process.argv);
@@ -30,7 +30,7 @@ if (storjshare_restart.remote) {
 
 utils.connectToDaemon(port, function(rpc, sock) {
   if (storjshare_restart.all) {
-    console.info('\n  * restarting all managed shares');
+    console.info('\n  * restarting all managed nodes');
   }
 
   rpc.restart(storjshare_restart.nodeid || '*', (err) => {
@@ -42,7 +42,7 @@ utils.connectToDaemon(port, function(rpc, sock) {
     if (storjshare_restart.nodeid) {
       console.info(`\n  * share ${storjshare_restart.nodeid} restarted`);
     } else {
-      console.info('\n  * all shares restarted successfully');
+      console.info('\n  * all nodes restarted successfully');
     }
 
     sock.end();

--- a/bin/storjshare-save.js
+++ b/bin/storjshare-save.js
@@ -9,7 +9,7 @@ const utils = require('../lib/utils');
 const storjshare_save = require('commander');
 
 storjshare_save
-  .description('saves a snapshot of shares')
+  .description('saves a snapshot of nodes')
   .option('-s, --snapshot <path>', 'path to write the snapshot file')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')

--- a/bin/storjshare-start.js
+++ b/bin/storjshare-start.js
@@ -9,9 +9,9 @@ const config = require('../lib/config/daemon');
 const storjshare_start = require('commander');
 
 storjshare_start
-  .description('starts a new network share')
+  .description('starts a new network node')
   .option('-c, --config <path>', 'specify the configuration path')
-  .option('-d, --detached', 'run share without management from daemon')
+  .option('-d, --detached', 'run node without management from daemon')
   .option('-u, --unsafe', 'ignore system resource guards')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')
@@ -49,10 +49,10 @@ function runManagedShare() {
   utils.connectToDaemon(port, function(rpc, sock) {
     rpc.start(configPath, (err) => {
       if (err) {
-        console.error(`\n  failed to start share, reason: ${err.message}`);
+        console.error(`\n  failed to start node, reason: ${err.message}`);
         return sock.end();
       }
-      console.info(`\n  * starting share with config at ${configPath}`);
+      console.info(`\n  * starting node with config at ${configPath}`);
       sock.end();
     }, storjshare_start.unsafe);
   }, address);

--- a/bin/storjshare-status.js
+++ b/bin/storjshare-status.js
@@ -10,11 +10,11 @@ const colors = require('colors/safe');
 const storjshare_status = require('commander');
 
 storjshare_status
-  .description('prints the status of all managed shares')
+  .description('prints the status of all managed nodes')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')
   .option('-j, --json',
-    'JSON formatted status of all managed shares')
+    'JSON formatted status of all managed nodes')
   .parse(process.argv);
 
 function getColoredValue(status, value) {

--- a/bin/storjshare-stop.js
+++ b/bin/storjshare-stop.js
@@ -7,8 +7,8 @@ const utils = require('../lib/utils');
 const storjshare_stop = require('commander');
 
 storjshare_stop
-  .description('stops the running share specified')
-  .option('-i, --nodeid <nodeid>', 'id of the running share')
+  .description('stops the running node specified')
+  .option('-i, --nodeid <nodeid>', 'id of the running node')
   .option('-r, --remote <hostname:port>',
     'hostname and optional port of the daemon')
   .parse(process.argv);

--- a/bin/storjshare.js
+++ b/bin/storjshare.js
@@ -26,10 +26,10 @@ storjshare
   .command('status', 'check status of node(s)')
   .command('logs', 'tail the logs for a node')
   .command('create', 'create a new configuration')
-  .command('save', 'snapshot the currently managed shares')
-  .command('load', 'load a snapshot of previously managed shares')
+  .command('save', 'snapshot the currently managed node')
+  .command('load', 'load a snapshot of previously managed nodes')
   .command('destroy', 'kills the farming node')
-  .command('killall', 'kills all shares and stops the daemon')
+  .command('killall', 'kills all nodes and stops the daemon')
   .command('daemon', 'starts the daemon')
   .parse(process.argv);
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -16,7 +16,7 @@ const {homedir} = require('os');
 class RPC {
 
   /**
-   * Creates a environment to manage share processes
+   * Creates a environment to manage node processes
    * @param {Object} options
    * @param {Number} options.logVerbosity
    */
@@ -35,11 +35,11 @@ class RPC {
   }
 
   /**
-   * Handles IPC messages from a running share
+   * Handles IPC messages from a running node
    * @private
    */
   _processShareIpc(share, msg) {
-    // NB: We receive a complete state object from shares when an event
+    // NB: We receive a complete state object from nodes when an event
     // NB: occurs that updates the state object
     share.meta.farmerState = msg;
   }
@@ -114,10 +114,10 @@ class RPC {
       path: configPath
     };
 
-    this._log(`attempting to start share with config at path ${configPath}`);
+    this._log(`attempting to start node with config at path ${configPath}`);
 
     if (this.shares.has(nodeId) && this.shares.get(nodeId).readyState === 1) {
-      return callback(new Error(`share ${nodeId} is already running`));
+      return callback(new Error(`node ${nodeId} is already running`));
     }
 
     utils.validateAllocation(share.config, (err) => {
@@ -163,19 +163,19 @@ class RPC {
         fslogger.write(data);
       });
 
-      // NB: Listen for state changes to update the share's record
+      // NB: Listen for state changes to update the node's record
       share.process.on('error', (err) => {
         share.readyState = RPC.SHARE_ERRORED;
         this._log(err.message, 'error');
         clearInterval(uptimeCounter);
       });
 
-      // NB: Listen for exits and restart the share if not stopped manually
+      // NB: Listen for exits and restart the node if not stopped manually
       share.process.on('exit', (code, signal) => {
         let maxRestartsReached = share.meta.numRestarts >= RPC.MAX_RESTARTS;
         share.readyState = RPC.SHARE_STOPPED;
 
-        this._log(`share ${nodeId} exited with code ${code}`);
+        this._log(`node ${nodeId} exited with code ${code}`);
         clearInterval(uptimeCounter);
 
         if (signal !== 'SIGINT' &&
@@ -198,15 +198,15 @@ class RPC {
    */
 
   /**
-   * Stops the share process for the given node ID
+   * Stops the node process for the given node ID
    * @param {String} nodeId
    * @param {RPC~stopCallback}
    */
   stop(nodeId, callback) {
-    this._log(`attempting to stop share with node id ${nodeId}`);
+    this._log(`attempting to stop node with node id ${nodeId}`);
 
     if (!this.shares.has(nodeId) || !this.shares.get(nodeId).readyState) {
-      return callback(new Error(`share ${nodeId} is not running`));
+      return callback(new Error(`node ${nodeId} is not running`));
     }
 
     this.shares.get(nodeId).process.kill('SIGINT');
@@ -244,7 +244,7 @@ class RPC {
    * @param {RPC~restartCallback}
    */
   restart(nodeId, callback) {
-    this._log(`attempting to restart share with node id ${nodeId}`);
+    this._log(`attempting to restart node with node id ${nodeId}`);
 
     if (nodeId === '*') {
       return async.eachSeries(
@@ -264,7 +264,7 @@ class RPC {
    */
 
   /**
-   * Returns status information about the running shares
+   * Returns status information about the running nodes
    * @param {RPC~statusCallback}
    */
   status(callback) {
@@ -293,7 +293,7 @@ class RPC {
    * Simply kills the daemon and all managed proccesses
    */
   killall(callback) {
-    this._log(`received kill signal, destroying running shares`);
+    this._log(`received kill signal, destroying running nodes`);
 
     for (let nodeId of this.shares.keys()) {
       this.destroy(nodeId, () => null);
@@ -304,7 +304,7 @@ class RPC {
   }
 
   /**
-   * Kills the share with the given node ID
+   * Kills the node with the given node ID
    * @param {String} nodeId
    * @param {RPC~destroyCallback}
    */
@@ -312,7 +312,7 @@ class RPC {
     this._log(`received destroy command for ${nodeId}`);
 
     if (!this.shares.has(nodeId) || !this.shares.get(nodeId).process) {
-      return callback(new Error(`share ${nodeId} is not running`));
+      return callback(new Error(`node ${nodeId} is not running`));
     }
 
     let share = this.shares.get(nodeId);
@@ -327,7 +327,7 @@ class RPC {
    */
 
   /**
-   * Saves the current shares configured
+   * Saves the current nodes configured
    * @param {String} writePath
    * @param {RPC~saveCallback}
    */
@@ -395,7 +395,7 @@ class RPC {
    */
 
   /**
-   * Returns the number of shares currently running
+   * Returns the number of nodes currently running
    * @private
    */
   get running() {


### PR DESCRIPTION
 Changes to be committed:
	modified:   bin/storjshare-create.js
	modified:   bin/storjshare-destroy.js
	modified:   bin/storjshare-killall.js
	modified:   bin/storjshare-load.js
	modified:   bin/storjshare-logs.js
	modified:   bin/storjshare-restart.js
	modified:   bin/storjshare-save.js
	modified:   bin/storjshare-start.js
	modified:   bin/storjshare-status.js
	modified:   bin/storjshare-stop.js
	modified:   bin/storjshare.js
	modified:   lib/api.js

Changes wording from "shares" & "share" to "nodes" & "node" to make it more uniform.

  As requested in issue #110 it can be confusing for new users to distinguish the meaning between node and share.  As they are one in the same, I leaned towards node and replaced the
word share where it is output.  (I only replaced human readables, no variables, parameters, or fields were touched.)