### PR TITLE
Easier node+npm install instructions for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Make sure you have the following prerequisites installed:
 
 ### Node.js + NPM
 
+#### Debian/Ubuntu
+
+```
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+sudo apt-get install nodejs
+```
+
 #### GNU+Linux & Mac OSX
 
 ```


### PR DESCRIPTION
I wasn't able to install node+npm on my RaspberryPi with nvm.
I found [another way](https://github.com/nodesource/distributions) to do that and it should be helpful for others.