### PR TITLE
Set default Tunnel Configuration to "not allowed"

### DIFF
--- a/example/farmer.config.json
+++ b/example/farmer.config.json
@@ -34,14 +34,14 @@
   "doNotTraverseNat": false,
   // Maximum number of tunnels to provide to the network
   // Tunnels help nodes with restrictive network configurations participate
-  "maxTunnels": 3,
+  "maxTunnels": 0,
   // Maximum number of concurrent connections to allow
   "maxConnections": 150,
   // If providing tunnels, the starting and ending port range to open for
   // them
   "tunnelGatewayRange": {
-    "min": 4001,
-    "max": 4003
+    "min": 0,
+    "max": 0
   },
   // Number of times to retry joining the network and the wait time between
   "joinRetry": {


### PR DESCRIPTION
Tunnel Connections are not stable enough with regards to SIP09 and are also bad for performance.
Further it increases the chances to mark a legit farmer as a cheater when creating the payout sheet, when multiple Payment Addresses are running over a single IP.