### PR TITLE
Add a title for Install section in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ npm install --global windows-build-tools
 
 ---
 
+### Install ###
+
 Once build dependencies have been installed for your platform, install the
 package globally using Node Package Manager:
 


### PR DESCRIPTION
There are headers for all sections of the readme file, except for the install package section.
For coherence but also for accessibility reasons it might be reasonable to also have a title here.