### PR TITLE
reload share's config that cached in daemon when farmer node restart

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -114,6 +114,8 @@ class RPC {
       path: configPath
     };
 
+    share.config = config;
+
     this._log(`attempting to start node with config at path ${configPath}`);
 
     if (this.shares.has(nodeId) && this.shares.get(nodeId).readyState === 1) {


### PR DESCRIPTION
reload share's config that cached in daemon when farmer node restart
当节点重启时，更新daemon里缓存的节点配置。这样通过status方法就能获取到最新的配置。